### PR TITLE
adding blank check

### DIFF
--- a/_mulitple_app_signup_form.html.liquid
+++ b/_mulitple_app_signup_form.html.liquid
@@ -51,7 +51,9 @@
                               	<div class="row">
                     		  		<div class="col-md-12">
                       					<input type="checkbox" name="plan_ids[]" value="{{ plan.id }}">Signup to {{ plan.name }}</input>
-                                <input type="hidden" name="plan_ids[]" value="{{ service.service_plans.first.id }}"></input>
+                                        {% if service.service_plans.first.id != blank %}
+                                           <input type="hidden" name="plan_ids[]" value="{{ service.service_plans.first.id }}"></input>
+                                        {% endif %}
                     				</div>
                   				</div>
                           		


### PR DESCRIPTION
If service.service_plans.first.id was blank, the sign up button was submitting to a url with empty parameters, like: "https://${ADMIN_PORTAL}/signup?plan_ids[]=&plan_ids[]=2357355990346&plan_ids[]=&plan_ids[]=&plan_ids[]=" and a consequent Not Found error being displayed on the browser.